### PR TITLE
Add `defaultValue` info for "uncontrolled" forms

### DIFF
--- a/apps/mantine.dev/src/pages/form/get-input-props.mdx
+++ b/apps/mantine.dev/src/pages/form/get-input-props.mdx
@@ -6,7 +6,7 @@ export default Layout(MDX_DATA.formGetInputProps);
 
 ## getInputProps handler
 
-`form.getInputProps` returns an object with `value`, `onChange`, `onFocus`, `onBlur`, `error`
+`form.getInputProps` returns an object with `value` (`defaultValue` for "uncontrolled" mode), `onChange`, `onFocus`, `onBlur`, `error`
 and all props specified in `enhanceGetInputProps` function. Return value should be spread to the input component.
 
 You can pass the following options to `form.getInputProps` as second argument:


### PR DESCRIPTION
While working with "uncontrolled" forms I've found out that `value` was missing from `form.getInputProps()` and instead it was `defaultValue`.

I couldn't find anything in the docs but I did find the test suite clarifying it here: https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/form/src/tests/use-form/getInputProps.test.ts

